### PR TITLE
Fix installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,6 @@ submit: schemas
 
 install:
 	rm -rf ~/.local/share/gnome-shell/extensions/unblank@sun.wxg@gmail.com
-	cp -r unblank@sun.wxg@gmail.com ~/.local/share/gnome-shell/extensions/
+	mkdir -p ~/.local/share/gnome-shell/extensions/unblank@sun.wxg@gmail.com
+	cp -r unblank@sun.wxg@gmail.com/* ~/.local/share/gnome-shell/extensions/unblank@sun.wxg@gmail.com/
 


### PR DESCRIPTION
Without the slash `/` at the end it does copy the directory contents directly into `~/.local/share/gnome-shell/extensions/` and the extension can not be installed (on Arch Linux at least).