### PR TITLE
feature: add GNOME shell 47

### DIFF
--- a/unblank@sun.wxg@gmail.com/metadata.json
+++ b/unblank@sun.wxg@gmail.com/metadata.json
@@ -7,7 +7,8 @@
   "description": "Unblank lock screen.",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "original-authors": "sun.wxg@gmail.com",
   "url": "https://github.com/sunwxg/gnome-shell-extension-unblank"


### PR DESCRIPTION
I simply added the new GNOME shell version `47` to metadata.json.

I don't think there's anything to change according to [the docs](https://gjs.guide/extensions/upgrading/gnome-shell-47.html).

I tested it on GNOME 47.0.

It resolves https://github.com/sunwxg/gnome-shell-extension-unblank/issues/35.