### PR TITLE
Add Gnome 50 as supported shell version

### DIFF
--- a/unblank@sun.wxg@gmail.com/metadata.json
+++ b/unblank@sun.wxg@gmail.com/metadata.json
@@ -10,7 +10,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "original-authors": "sun.wxg@gmail.com",
   "url": "https://github.com/sunwxg/gnome-shell-extension-unblank"


### PR DESCRIPTION
Simple change to add Gnome 50 as a supported version in the metadata, works without problems for me on Fedora 44 Beta